### PR TITLE
avoid UIPasteboard crash when set string with nil value

### DIFF
--- a/AvoidCrash/AvoidCrash.h
+++ b/AvoidCrash/AvoidCrash.h
@@ -29,6 +29,8 @@
 #import "NSAttributedString+AvoidCrash.h"
 #import "NSMutableAttributedString+AvoidCrash.h"
 
+#import "UIPasteboard+AvoidCrash.h"
+
 //define
 #import "AvoidCrashStubProxy.h"
 

--- a/AvoidCrash/AvoidCrash.m
+++ b/AvoidCrash/AvoidCrash.m
@@ -48,6 +48,8 @@
         
         [NSAttributedString avoidCrashExchangeMethod];
         [NSMutableAttributedString avoidCrashExchangeMethod];
+        
+        [UIPasteboard avoidCrashExchangeMethod];
     });
 }
 

--- a/AvoidCrash/UIPasteboard+AvoidCrash.h
+++ b/AvoidCrash/UIPasteboard+AvoidCrash.h
@@ -1,0 +1,18 @@
+//
+//  UIPasteboard+AvoidCrash.h
+//  AvoidCrashDemo
+//
+//  Created by Justin.wang on 2019/3/26.
+//  Copyright © 2019年 chenfanfang. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+#import "AvoidCrashProtocol.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface UIPasteboard (AvoidCrash)<AvoidCrashProtocol>
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/AvoidCrash/UIPasteboard+AvoidCrash.m
+++ b/AvoidCrash/UIPasteboard+AvoidCrash.m
@@ -1,0 +1,36 @@
+//
+//  UIPasteboard+AvoidCrash.m
+//  AvoidCrashDemo
+//
+//  Created by Justin.wang on 2019/3/26.
+//  Copyright © 2019年 chenfanfang. All rights reserved.
+//
+
+#import "UIPasteboard+AvoidCrash.h"
+#import "AvoidCrash.h"
+
+@implementation UIPasteboard (AvoidCrash)
+
++ (void)avoidCrashExchangeMethod {
+    
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        Class cls = NSClassFromString(@"_UIConcretePasteboard");
+        [AvoidCrash exchangeInstanceMethod:cls
+                               method1Sel:@selector(setString:)
+                               method2Sel:@selector(avoidCrashSetString:)];
+    });
+}
+
+- (void)avoidCrashSetString:(NSString *)string {
+    @try {
+       [self avoidCrashSetString:string];
+    }
+    @catch (NSException *exception) {
+        NSString *defaultToDo = AvoidCrashDefaultIgnore;
+        [AvoidCrash noteErrorWithException:exception defaultToDo:defaultToDo];
+    }
+   
+}
+
+@end

--- a/AvoidCrashDemo/AvoidCrashDemo.xcodeproj/project.pbxproj
+++ b/AvoidCrashDemo/AvoidCrashDemo.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		04FB61D91DB2361400C079F2 /* NSAttributedString+AvoidCrash.m in Sources */ = {isa = PBXBuildFile; fileRef = 04FB61D81DB2361400C079F2 /* NSAttributedString+AvoidCrash.m */; };
 		04FB61DC1DB25FE500C079F2 /* NSMutableAttributedString+AvoidCrash.m in Sources */ = {isa = PBXBuildFile; fileRef = 04FB61DB1DB25FE500C079F2 /* NSMutableAttributedString+AvoidCrash.m */; };
 		04FEB8FF1DA55E6B00B5647E /* NSMutableString+AvoidCrash.m in Sources */ = {isa = PBXBuildFile; fileRef = 04FEB8FE1DA55E6B00B5647E /* NSMutableString+AvoidCrash.m */; };
+		BAE580A4224A14C600CFAD9E /* UIPasteboard+AvoidCrash.m in Sources */ = {isa = PBXBuildFile; fileRef = BAE580A3224A14C600CFAD9E /* UIPasteboard+AvoidCrash.m */; };
 		F61CF29C1FF2206D006093D9 /* AvoidCrashPerson.m in Sources */ = {isa = PBXBuildFile; fileRef = F61CF29B1FF2206D006093D9 /* AvoidCrashPerson.m */; };
 		F63018CE1F22EFA000F176DF /* Person.m in Sources */ = {isa = PBXBuildFile; fileRef = F63018CD1F22EFA000F176DF /* Person.m */; };
 		F6EBB7B51F271CCB00ED3B15 /* AvoidCrashStubProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = F6EBB7B41F271CCB00ED3B15 /* AvoidCrashStubProxy.m */; };
@@ -84,6 +85,8 @@
 		04FB61DB1DB25FE500C079F2 /* NSMutableAttributedString+AvoidCrash.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSMutableAttributedString+AvoidCrash.m"; sourceTree = "<group>"; };
 		04FEB8FD1DA55E6B00B5647E /* NSMutableString+AvoidCrash.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSMutableString+AvoidCrash.h"; sourceTree = "<group>"; };
 		04FEB8FE1DA55E6B00B5647E /* NSMutableString+AvoidCrash.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSMutableString+AvoidCrash.m"; sourceTree = "<group>"; };
+		BAE580A2224A14C600CFAD9E /* UIPasteboard+AvoidCrash.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIPasteboard+AvoidCrash.h"; sourceTree = "<group>"; };
+		BAE580A3224A14C600CFAD9E /* UIPasteboard+AvoidCrash.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "UIPasteboard+AvoidCrash.m"; sourceTree = "<group>"; };
 		F61CF29A1FF2206D006093D9 /* AvoidCrashPerson.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AvoidCrashPerson.h; sourceTree = "<group>"; };
 		F61CF29B1FF2206D006093D9 /* AvoidCrashPerson.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AvoidCrashPerson.m; sourceTree = "<group>"; };
 		F63018CC1F22EFA000F176DF /* Person.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Person.h; sourceTree = "<group>"; };
@@ -211,6 +214,8 @@
 				04FB61D81DB2361400C079F2 /* NSAttributedString+AvoidCrash.m */,
 				04FB61DA1DB25FE500C079F2 /* NSMutableAttributedString+AvoidCrash.h */,
 				04FB61DB1DB25FE500C079F2 /* NSMutableAttributedString+AvoidCrash.m */,
+				BAE580A2224A14C600CFAD9E /* UIPasteboard+AvoidCrash.h */,
+				BAE580A3224A14C600CFAD9E /* UIPasteboard+AvoidCrash.m */,
 			);
 			name = AvoidCrash;
 			path = ../../AvoidCrash;
@@ -363,6 +368,7 @@
 				04FB61DC1DB25FE500C079F2 /* NSMutableAttributedString+AvoidCrash.m in Sources */,
 				F63018CE1F22EFA000F176DF /* Person.m in Sources */,
 				043C64241D93A60C00A0B0E9 /* NSMutableDictionary+AvoidCrash.m in Sources */,
+				BAE580A4224A14C600CFAD9E /* UIPasteboard+AvoidCrash.m in Sources */,
 				043C64201D93A60C00A0B0E9 /* AvoidCrash.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/AvoidCrashDemo/AvoidCrashDemo/ViewController.m
+++ b/AvoidCrashDemo/AvoidCrashDemo/ViewController.m
@@ -306,7 +306,6 @@
 }
 
 
-
 //=================================================================
 //                            KVC
 //=================================================================
@@ -355,6 +354,16 @@
     id person = [AvoidCrashPerson new];
     [person objectForKey:@"key"];
 }
+
+
+//=================================================================
+//                   UIPasteboard
+//=================================================================
+- (void)UIPasteboard_Test_SetStringWithNil {
+    UIPasteboard *pasteboard = [UIPasteboard generalPasteboard];
+    [pasteboard setString:nil];
+}
+
 
 //=================================================================
 //                      执行所有test的方法
@@ -411,6 +420,8 @@
     
     [self testNoSelectorCrash];
     [self testNoSelectorCrash2];
+    
+    [self UIPasteboard_Test_SetStringWithNil];
 }
 
 


### PR DESCRIPTION
当UIPasteboard调用setString方法时，如果参数值为nil，会造成crash
