### PR TITLE
对部分没有预防的API进行完善处理

### DIFF
--- a/AvoidCrash/NSMutableAttributedString+AvoidCrash.h
+++ b/AvoidCrash/NSMutableAttributedString+AvoidCrash.h
@@ -20,4 +20,13 @@
  *
  *  1.- (instancetype)initWithString:(NSString *)str
  *  2.- (instancetype)initWithString:(NSString *)str attributes:(NSDictionary<NSString *,id> *)attrs
+ *  3.- (void)addAttribute:(NSAttributedStringKey)name value:(id)value range:(NSRange)range;
+ *  4.- (void)addAttributes:(NSDictionary<NSAttributedStringKey, id> *)attrs range:(NSRange)range;
+ *  5.- (void)removeAttribute:(NSAttributedStringKey)name range:(NSRange)range;
+ 
+ *  6.- (void)replaceCharactersInRange:(NSRange)range withAttributedString:(NSAttributedString *)attrString;
+ *  7.- (void)insertAttributedString:(NSAttributedString *)attrString atIndex:(NSUInteger)loc;
+ *  8.- (void)appendAttributedString:(NSAttributedString *)attrString;
+ *  9.- (void)deleteCharactersInRange:(NSRange)range;
+ *  10.- (void)setAttributedString:(NSAttributedString *)attrString;
  */

--- a/AvoidCrash/NSMutableAttributedString+AvoidCrash.m
+++ b/AvoidCrash/NSMutableAttributedString+AvoidCrash.m
@@ -24,6 +24,29 @@
         
         //initWithString:attributes:
         [AvoidCrash exchangeInstanceMethod:NSConcreteMutableAttributedString method1Sel:@selector(initWithString:attributes:) method2Sel:@selector(avoidCrashInitWithString:attributes:)];
+        
+        //addAttribute:value:range:
+        [AvoidCrash exchangeInstanceMethod:NSConcreteMutableAttributedString method1Sel:@selector(addAttribute:value:range:) method2Sel:@selector(avoidCrashAddAttribute:value:range:)];
+        
+        //addAttributes:range:
+        [AvoidCrash exchangeInstanceMethod:NSConcreteMutableAttributedString method1Sel:@selector(addAttributes:range:) method2Sel:@selector(avoidCrashAddAttributes:range:)];
+        
+        //removeAttribute:range:
+        [AvoidCrash exchangeInstanceMethod:NSConcreteMutableAttributedString method1Sel:@selector(removeAttribute:range:) method2Sel:@selector(avoidCrashRemoveAttributes:range:)];
+        
+        //replaceCharactersInRange:withString:
+        [AvoidCrash exchangeInstanceMethod:NSConcreteMutableAttributedString method1Sel:@selector(replaceCharactersInRange:withAttributedString:) method2Sel:@selector(avoidCrashReplaceCharactersInRange:withAttributedString:)];
+        
+        //insertAttributedString:atIndex:
+        [AvoidCrash exchangeInstanceMethod:NSConcreteMutableAttributedString method1Sel:@selector(insertAttributedString:atIndex:) method2Sel:@selector(avoidCrashInsertAttributedString:atIndex:)];
+         
+         //appendString:
+         [AvoidCrash exchangeInstanceMethod:NSConcreteMutableAttributedString method1Sel:@selector(appendString:) method2Sel:@selector(avoidCrashAppendAttributedString:)];
+        
+        //setAttributedString:
+        [AvoidCrash exchangeInstanceMethod:NSConcreteMutableAttributedString method1Sel:@selector(setAttributedString:) method2Sel:@selector(avoidCrashSetAttributedString:)];
+        
+        
     });
 }
 
@@ -70,5 +93,133 @@
     }
 }
 
+//=================================================================
+//                     addAttribute:(NSAttributedStringKey)name value:(id)value range:(NSRange)range;
+//=================================================================
+#pragma mark - addAttribute:(NSAttributedStringKey)name value:(id)value range:(NSRange)range
+- (void)avoidCrashAddAttribute:(NSAttributedStringKey)name value:(id)value range:(NSRange)range{
+    @try {
+        [self avoidCrashAddAttribute:name value:value range:range];
+    }
+    @catch (NSException *exception) {
+        [AvoidCrash noteErrorWithException:exception defaultToDo:AvoidCrashDefaultIgnore];
+    }
+    @finally {
+        
+    }
+}
+
+//=================================================================
+//                     addAttributes:(NSDictionary<NSAttributedStringKey, id> *)attrs range:(NSRange)range;
+//=================================================================
+#pragma mark - addAttributes:(NSDictionary<NSAttributedStringKey, id> *)attrs range:(NSRange)range
+- (void)avoidCrashAddAttributes:(NSDictionary<NSAttributedStringKey, id> *)attrs range:(NSRange)range{
+    @try{
+        [self avoidCrashAddAttributes:attrs range:range];
+    }
+    @catch (NSException *exception){
+        [AvoidCrash noteErrorWithException:exception defaultToDo:AvoidCrashDefaultIgnore];
+    }
+    @finally {
+        
+    }
+}
+
+//=================================================================
+//                     - (void)avoidCrashRemoveAttributes:(NSAttributedStringKey)name range:(NSRange)range;
+//=================================================================
+#pragma mark - removeAttributes:(NSAttributedStringKey)name range:(NSRange)range
+- (void)avoidCrashRemoveAttributes:(NSAttributedStringKey)name range:(NSRange)range{
+    @try {
+        [self avoidCrashRemoveAttributes:name range:range];
+    }
+    @catch (NSException *exception) {
+        [AvoidCrash noteErrorWithException:exception defaultToDo:AvoidCrashDefaultIgnore];
+    }
+    @finally {
+        
+    }
+}
+
+//=================================================================
+//                     - (void)avoidCrashReplaceCharactersInRange:(NSRange)range withAttributedString:(NSAttributedString *)attrString;
+//=================================================================
+#pragma mark - replaceCharactersInRange:(NSRange)range withAttributedString:(NSAttributedString *)attrString
+- (void)avoidCrashReplaceCharactersInRange:(NSRange)range withAttributedString:(NSAttributedString *)attrString{
+    @try {
+        [self avoidCrashReplaceCharactersInRange:range withAttributedString:attrString];
+    }
+    @catch (NSException *exception) {
+        [AvoidCrash noteErrorWithException:exception defaultToDo:AvoidCrashDefaultIgnore];
+    }
+    @finally {
+        
+    }
+}
+
+//=================================================================
+//                     - (void)insertAttributedString:(NSAttributedString *)attrString atIndex:(NSUInteger)loc;
+//=================================================================
+#pragma mark - insertAttributedString:(NSAttributedString *)attrString atIndex:(NSUInteger)loc
+- (void)avoidCrashInsertAttributedString:(NSAttributedString *)attrString atIndex:(NSUInteger)loc{
+    @try {
+        [self avoidCrashInsertAttributedString:attrString atIndex:loc];
+    }
+    @catch (NSException *exception) {
+        [AvoidCrash noteErrorWithException:exception defaultToDo:AvoidCrashDefaultIgnore];
+    }
+    @finally {
+    
+    }
+}
+
+
+//=================================================================
+//                     - (void)appendAttributedString:(NSAttributedString *)attrString;
+//=================================================================
+#pragma mark - appendAttributedString:(NSAttributedString *)attrString
+- (void)avoidCrashAppendAttributedString:(NSAttributedString *)attrString{
+    @try {
+        [self avoidCrashAppendAttributedString:attrString];
+    }
+    @catch (NSException *exception) {
+        [AvoidCrash noteErrorWithException:exception defaultToDo:AvoidCrashDefaultIgnore];
+    }
+    @finally {
+        
+    }
+}
+
+//=================================================================
+//                     - (void)deleteCharactersInRange:(NSRange)range;
+//=================================================================
+#pragma mark - deleteCharactersInRange:(NSRange)range
+- (void)avoidCrashDeleteCharactersInRange:(NSRange)range{
+    @try {
+        [self avoidCrashDeleteCharactersInRange:range];
+    }
+    @catch (NSException *exception) {
+        [AvoidCrash noteErrorWithException:exception defaultToDo:AvoidCrashDefaultIgnore];
+    }
+    @finally {
+        
+    }
+}
+
+
+//=================================================================
+//                     - (void)setAttributedString:(NSAttributedString *)attrString;
+//=================================================================
+- (void)avoidCrashSetAttributedString:(NSAttributedString *)attrString{
+    @try {
+        [self avoidCrashSetAttributedString:attrString];
+    }
+    @catch (NSException *exception) {
+        [AvoidCrash noteErrorWithException:exception defaultToDo:AvoidCrashDefaultIgnore];
+    }
+    @finally {
+        
+    }
+}
 
 @end

--- a/AvoidCrash/NSString+AvoidCrash.m
+++ b/AvoidCrash/NSString+AvoidCrash.m
@@ -38,6 +38,9 @@
         
         //stringByReplacingCharactersInRange:withString:
         [AvoidCrash exchangeInstanceMethod:stringClass method1Sel:@selector(stringByReplacingCharactersInRange:withString:) method2Sel:@selector(avoidCrashStringByReplacingCharactersInRange:withString:)];
+        
+        //stringByAppendingString:
+        [AvoidCrash exchangeInstanceMethod:stringClass method1Sel:@selector(stringByAppendingString:) method2Sel:@selector(avoidCrashStringByAppendingString:)];
     });
     
 }
@@ -189,6 +192,27 @@
     
     @try {
         newStr = [self avoidCrashStringByReplacingCharactersInRange:range withString:replacement];
+    }
+    @catch (NSException *exception) {
+        NSString *defaultToDo = AvoidCrashDefaultReturnNil;
+        [AvoidCrash noteErrorWithException:exception defaultToDo:defaultToDo];
+        newStr = nil;
+    }
+    @finally {
+        return newStr;
+    }
+}
+
+
+//=================================================================
+//       avoidCrashStringByAppendingString:
+//=================================================================
+#pragma mark - avoidCrashStringByAppendingString:
+
+- (NSString *)avoidCrashStringByAppendingString:(NSString *)aString{
+    NSString *newStr = nil;
+    @try {
+        newStr = [self avoidCrashStringByAppendingString:aString];
     }
     @catch (NSException *exception) {
         NSString *defaultToDo = AvoidCrashDefaultReturnNil;

--- a/AvoidCrashDemo/AvoidCrashDemo/ViewController.m
+++ b/AvoidCrashDemo/AvoidCrashDemo/ViewController.m
@@ -231,6 +231,12 @@
     NSLog(@"%@",str);
 }
 
+- (void)NSString_Test_stringByAppendingString {
+    NSString *str = @"TEST";
+    NSString *nilString = nil;
+    str = [str stringByAppendingString:nilString];
+    NSLog(@"%@",str);
+}
 
 //=================================================================
 //                       NSMutableString_Test
@@ -305,6 +311,110 @@
     NSLog(@"%@",attrStrM);
 }
 
+- (void)NSMutableAttributedString_Test_AddAttributeValueRange{
+    NSDictionary *attributes = @{
+                                 NSForegroundColorAttributeName : [UIColor redColor]
+                                 };
+     NSMutableAttributedString *attrStrM = [[NSMutableAttributedString alloc] initWithString:@"TEST" attributes:attributes];
+    NSString *nilAtrrbutedName = nil;
+    [attrStrM addAttribute:nilAtrrbutedName value:[UIFont systemFontOfSize:12.0] range:NSMakeRange(0, [attrStrM.string length])];
+    
+    UIFont *nilFont = nil;
+    [attrStrM addAttribute:NSFontAttributeName value:nilFont range:NSMakeRange(0, [attrStrM.string length])];
+    
+    NSRange outOfRange = NSMakeRange(0, attrStrM.length + 100);
+    [attrStrM addAttribute:NSFontAttributeName value:[UIFont systemFontOfSize:12.0] range:outOfRange];
+    
+    [attrStrM addAttribute:nilAtrrbutedName value:nilFont range:outOfRange];
+}
+
+- (void)NSMutableAttributedString_Test_AddAttributesRange{
+    NSDictionary *attributes = @{
+                                 NSForegroundColorAttributeName : [UIColor redColor]
+                                 };
+    NSDictionary *nilAttributes = nil;
+    NSMutableAttributedString *attrStrM = [[NSMutableAttributedString alloc] initWithString:@"TEST" attributes:attributes];
+    
+    [attrStrM addAttributes:nilAttributes range:NSMakeRange(0, [attrStrM.string length])];
+    NSRange outOfRange = NSMakeRange(0, attrStrM.length + 100);
+    
+    [attrStrM addAttributes:attributes range:outOfRange];
+    
+    [attrStrM addAttributes:nilAttributes range:outOfRange];
+}
+ 
+- (void)NSMutableAttributedString_Test_RemoveAttributesRange{
+    NSDictionary *attributes = @{
+                                 NSForegroundColorAttributeName : [UIColor redColor]
+                                 };
+    NSMutableAttributedString *attrStrM = [[NSMutableAttributedString alloc] initWithString:@"TEST" attributes:attributes];
+    NSString *nilAttributedName = nil;
+    [attrStrM removeAttribute:nilAttributedName range:NSMakeRange(0, attrStrM.length)];
+    
+    NSRange outOfRange = NSMakeRange(0, attrStrM.length + 100);
+    [attrStrM removeAttribute:NSForegroundColorAttributeName range:outOfRange];
+    
+    [attrStrM removeAttribute:nilAttributedName range:outOfRange];
+}
+
+- (void)NSMutableAttributedString_Test_ReplaceCharactersInRangeWithAttributedString{
+    NSDictionary *attributes = @{
+                                 NSForegroundColorAttributeName : [UIColor redColor]
+                                 };
+    NSMutableAttributedString *attrStrM = [[NSMutableAttributedString alloc] initWithString:@"TEST" attributes:attributes];
+    NSAttributedString *nilAttributedString = nil;
+    [attrStrM replaceCharactersInRange:NSMakeRange(0, attrStrM.length) withAttributedString:nilAttributedString];
+    
+    NSRange outOfRange = NSMakeRange(0, attrStrM.length);
+    NSAttributedString *attributedString = [[NSAttributedString alloc] initWithString:@"ABC" attributes:attributes];
+    [attrStrM replaceCharactersInRange:outOfRange withAttributedString:attributedString];
+    
+    [attrStrM replaceCharactersInRange:outOfRange withAttributedString:nilAttributedString];
+}
+
+- (void)NSMutableAttributedString_Test_InsertAttributedStringAtIndex{
+    NSDictionary *attributes = @{
+                                 NSForegroundColorAttributeName : [UIColor redColor]
+                                 };
+    NSMutableAttributedString *attrStrM = [[NSMutableAttributedString alloc] initWithString:@"TEST" attributes:attributes];
+    NSAttributedString *nilAttributedString = nil;
+    [attrStrM insertAttributedString:nilAttributedString atIndex:0];
+    
+    NSAttributedString *attributedString = [[NSAttributedString alloc] initWithString:@"ABC" attributes:attributes];
+    NSInteger outIndex = attrStrM.length + 100;
+    [attrStrM insertAttributedString:attributedString atIndex:outIndex];
+    
+    [attrStrM insertAttributedString:nilAttributedString atIndex:outIndex];
+}
+
+- (void)NSMutableAttributedString_Test_AppendAttributedString{
+    NSDictionary *attributes = @{
+                                 NSForegroundColorAttributeName : [UIColor redColor]
+                                 };
+    NSMutableAttributedString *attrStrM = [[NSMutableAttributedString alloc] initWithString:@"TEST" attributes:attributes];
+    
+    NSAttributedString *nilAttributedString = nil;
+    [attrStrM appendAttributedString:nilAttributedString];
+}
+
+- (void)NSMutableAttributedString_Test_DeleteCharactersInRange{
+    NSDictionary *attributes = @{
+                                 NSForegroundColorAttributeName : [UIColor redColor]
+                                 };
+    NSMutableAttributedString *attrStrM = [[NSMutableAttributedString alloc] initWithString:@"TEST" attributes:attributes];
+    NSRange outOfRange = NSMakeRange(0, attrStrM.length);
+    
+    [attrStrM deleteCharactersInRange:outOfRange];
+}
+
+- (void)NSMutableAttributedString_Test_SetAttributedString{
+    NSDictionary *attributes = @{
+                                 NSForegroundColorAttributeName : [UIColor redColor]
+                                 };
+    NSMutableAttributedString *attrStrM = [[NSMutableAttributedString alloc] initWithString:@"TEST" attributes:attributes];
+    NSAttributedString *nilAttributedString = nil;
+    [attrStrM setAttributedString:nilAttributedString];
+}
 
 
 //=================================================================
@@ -388,7 +498,7 @@
     [self NSString_Test_StringByReplacingOccurrencesOfString];
     [self NSString_Test_StringByReplacingOccurrencesOfStringRange];
     [self NSString_Test_stringByReplacingCharactersInRangeWithString];
-    
+    [self NSString_Test_stringByAppendingString];
     
     [self NSMutableString_Test_ReplaceCharactersInRange];
     [self NSMutableString_Test_InsertStringAtIndex];
@@ -402,6 +512,14 @@
     
     [self NSMutableAttributedString_Test_InitWithString];
     [self NSMutableAttributedString_Test_InitWithStringAttributes];
+    [self NSMutableAttributedString_Test_AddAttributeValueRange];
+    [self NSMutableAttributedString_Test_AddAttributesRange];
+    [self NSMutableAttributedString_Test_RemoveAttributesRange];
+    [self NSMutableAttributedString_Test_ReplaceCharactersInRangeWithAttributedString];
+    [self NSMutableAttributedString_Test_InsertAttributedStringAtIndex];
+    [self NSMutableAttributedString_Test_AppendAttributedString];
+    [self NSMutableAttributedString_Test_DeleteCharactersInRange];
+    [self NSMutableAttributedString_Test_SetAttributedString];
     
     
     [self KVC_Test_SetValueForKey];

--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ pod 'AvoidCrash', '~> 2.5.2'
 	- `5. - (NSString *)stringByReplacingOccurrencesOfString:(NSString *)target withString:(NSString *)replacement`
 	- `6. - (NSString *)stringByReplacingOccurrencesOfString:(NSString *)target withString:(NSString *)replacement options:(NSStringCompareOptions)options range:(NSRange)searchRange`
 	- `7. - (NSString *)stringByReplacingCharactersInRange:(NSRange)range withString:(NSString *)replacement`
-
+       - `8. - (NSString *)stringByAppendingString:(NSString *)aString;
 ---
 
 
@@ -280,6 +280,15 @@ pod 'AvoidCrash', '~> 2.5.2'
 - NSMutableAttributedString
   -  `1.- (instancetype)initWithString:(NSString *)str`
   -  `2.- (instancetype)initWithString:(NSString *)str attributes:(NSDictionary<NSString *,id> *)attrs`
+  -  3.- (void)addAttribute:(NSAttributedStringKey)name value:(id)value range:(NSRange)range;
+  -  4.- (void)addAttributes:(NSDictionary<NSAttributedStringKey, id> *)attrs range:(NSRange)range;
+  -  5.- (void)removeAttribute:(NSAttributedStringKey)name range:(NSRange)range;
+  -  6.- (void)replaceCharactersInRange:(NSRange)range withAttributedString:(NSAttributedString *)attrString;
+  -  7.- (void)insertAttributedString:(NSAttributedString *)attrString atIndex:(NSUInteger)loc;
+  -  8.- (void)appendAttributedString:(NSAttributedString *)attrString;
+  -  9.- (void)deleteCharactersInRange:(NSRange)range;
+  -  10.- (void)setAttributedString:(NSAttributedString *)attrString;
+
 
 
 更新


### PR DESCRIPTION
1，对NSMutableAttributedString 的api增加了防崩溃处理
2，对NSString的 - (NSString *)stringByAppendingString:(NSString *)aString; 增加了防崩溃处理