### PR TITLE
方法签名优化

### DIFF
--- a/AvoidCrash/NSObject+AvoidCrash.m
+++ b/AvoidCrash/NSObject+AvoidCrash.m
@@ -104,26 +104,21 @@ static NSMutableArray *noneSelClassStringPrefixs;
     NSMethodSignature *ms = [self avoidCrashMethodSignatureForSelector:aSelector];
     
     if (ms) return ms;
+
+    for (NSString *classStr in noneSelClassStrings) {
+        if ([self isKindOfClass:NSClassFromString(classStr)]) {
+            return [AvoidCrashStubProxy instanceMethodSignatureForSelector:@selector(proxyMethod)];
+        }
+    }
     
-    BOOL flag = NO;
-    if (ms == nil) {
-        for (NSString *classStr in noneSelClassStrings) {
-            if ([self isKindOfClass:NSClassFromString(classStr)]) {
-                ms = [AvoidCrashStubProxy instanceMethodSignatureForSelector:@selector(proxyMethod)];
-                flag = YES;
-                break;
-            }
+    NSString *selfClass = NSStringFromClass([self class]);
+    for (NSString *classStrPrefix in noneSelClassStringPrefixs) {
+        if ([selfClass hasPrefix:classStrPrefix]) {
+            return [AvoidCrashStubProxy instanceMethodSignatureForSelector:@selector(proxyMethod)];
         }
     }
-    if (flag == NO) {
-        NSString *selfClass = NSStringFromClass([self class]);
-        for (NSString *classStrPrefix in noneSelClassStringPrefixs) {
-            if ([selfClass hasPrefix:classStrPrefix]) {
-                ms = [AvoidCrashStubProxy instanceMethodSignatureForSelector:@selector(proxyMethod)];
-            }
-        }
-    }
-    return ms;
+
+    return nil;
 }
 
 - (void)avoidCrashForwardInvocation:(NSInvocation *)anInvocation {

--- a/AvoidCrash/NSObject+AvoidCrash.m
+++ b/AvoidCrash/NSObject+AvoidCrash.m
@@ -103,6 +103,8 @@ static NSMutableArray *noneSelClassStringPrefixs;
     
     NSMethodSignature *ms = [self avoidCrashMethodSignatureForSelector:aSelector];
     
+    if (ms) return ms;
+    
     BOOL flag = NO;
     if (ms == nil) {
         for (NSString *classStr in noneSelClassStrings) {


### PR DESCRIPTION
有方法签名时直接返回，查找方法签名逻辑优化

解决与LookinServer混合使用时的崩溃 “getter 返回值不能为 void”